### PR TITLE
Add https:// to beginning of blog url if absent

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -2,13 +2,13 @@
   img: lordidiot.png
   skills: [pwn]
   desc: 0xdab
-  url: lordidiot.github.io
+  url: https://lordidiot.github.io
 
 - name: daniellimws
   img: daniellimws.png
   skills: [pwn, reverse engineering]
   desc: sleeping member
-  url: daniellimws.github.io
+  url: https://daniellimws.github.io
 
 - name: ShiRake
   img: shirake.png
@@ -19,4 +19,4 @@
   img: 
   skills: [web, reverse engineering, being useless]
   desc: <marquee>weeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee</marquee>
-  url: quanyang.github.io
+  url: https://quanyang.github.io

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -14,11 +14,7 @@
                     <h4>{{ member.desc }}</h4>
                     {% endif %}
                     {% if member.url %}
-                        {% if member.url contains "http" %}
-                            <a href="{{ member.url }}">{{ member.url }}</a>
-                        {% else %}
-                            <a href="https://{{ member.url }}">{{ member.url }}</a>
-                        {% endif %}
+                        <a href="{{ member.url }}">{{ member.url }}</a>
                     {% endif %}
                 </td>
             </tr>

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -14,7 +14,11 @@
                     <h4>{{ member.desc }}</h4>
                     {% endif %}
                     {% if member.url %}
-                    <a href="{{ member.url }}">{{ member.url }}</a>
+                        {% if member.url contains "http" %}
+                            <a href="{{ member.url }}">{{ member.url }}</a>
+                        {% else %}
+                            <a href="https://{{ member.url }}">{{ member.url }}</a>
+                        {% endif %}
                     {% endif %}
                 </td>
             </tr>


### PR DESCRIPTION
Currently our individual blog url doesn't have https:// in the `<a>`, so clicking it will bring us to hats.sg/quanyang.github.io for example.